### PR TITLE
Ensure zlib-flate doesn't link with an old libqpdf

### DIFF
--- a/zlib-flate/build.mk
+++ b/zlib-flate/build.mk
@@ -19,4 +19,4 @@ $(OBJS_zlib-flate): zlib-flate/$(OUTPUT_DIR)/%.$(OBJ): zlib-flate/%.cc
 	$(call compile,$<,$(INCLUDES_zlib-flate))
 
 zlib-flate/$(OUTPUT_DIR)/$(call binname,zlib-flate): $(OBJS_zlib-flate)
-	$(call makebin,$(OBJS_zlib-flate),$@,$(LDFLAGS) $(LDFLAGS_libqpdf),$(LIBS_libqpdf) $(LIBS))
+	$(call makebin,$(OBJS_zlib-flate),$@,$(LDFLAGS_libqpdf) $(LDFLAGS),$(LIBS_libqpdf) $(LIBS))


### PR DESCRIPTION
See: https://sourceforge.net/p/qpdf/bugs/17/

Parts of the fix for that bug report had previously been committed in 30dbf94f53a3fd9760242883bdc5bddbaa0c9f44 and 6299c64cf3351fb1935319378aed421e26ed2f90.